### PR TITLE
Add support for parsing BigTIFF exif data

### DIFF
--- a/exif/exif.go
+++ b/exif/exif.go
@@ -217,7 +217,7 @@ func loadSubDir(x *Exif, ptr FieldName, fieldMap map[uint16]FieldName) error {
 	if err != nil {
 		return fmt.Errorf("exif: seek to sub-IFD %s failed: %v", ptr, err)
 	}
-	subDir, _, err := tiff.DecodeDir(x.rawReader, x.Tiff.Order)
+	subDir, _, err := tiff.DecodeDir(x.rawReader, x.Tiff.Order, x.Tiff.IsBig)
 	if err != nil {
 		return fmt.Errorf("exif: sub-IFD %s decode failed: %v", ptr, err)
 	}
@@ -268,8 +268,14 @@ func Decode(r tiff.ReadAtReaderSeeker) (*Exif, error) {
 	case "II*\x00":
 		// TIFF - Little endian (Intel)
 		isTiff = true
+	case "II+\x00":
+		// BigTIFF - Little endian (Intel)
+		isTiff = true
 	case "MM\x00*":
 		// TIFF - Big endian (Motorola)
+		isTiff = true
+	case "MM\x00+":
+		// BigTIFF - Big endian (Motorola)
 		isTiff = true
 	default:
 		// Not TIFF, assume JPEG
@@ -509,7 +515,7 @@ func parse3Rat2(tag *tiff.Tag) ([3]float64, error) {
 			return v, err
 		}
 		v[i] = ratFloat(num, den)
-		if tag.Count < uint32(i+2) {
+		if tag.Count < uint64(i+2) {
 			break
 		}
 	}

--- a/mknote/mknote.go
+++ b/mknote/mknote.go
@@ -40,7 +40,7 @@ func (_ *canon) Parse(x *exif.Exif) error {
 	buf := bytes.NewReader(append(make([]byte, m.ValOffset), m.Val...))
 	buf.Seek(int64(m.ValOffset), 0)
 
-	mkNotesDir, _, err := tiff.DecodeDir(buf, x.Tiff.Order)
+	mkNotesDir, _, err := tiff.DecodeDir(buf, x.Tiff.Order, x.Tiff.IsBig)
 	if err != nil {
 		return err
 	}

--- a/tiff/tiff_test.go
+++ b/tiff/tiff_test.go
@@ -23,7 +23,7 @@ type input struct {
 type output struct {
 	id    uint16
 	typ   DataType
-	count uint32
+	count uint64
 	val   []byte
 }
 
@@ -146,7 +146,7 @@ func TestDecodeTag(t *testing.T) {
 func testSingle(t *testing.T, order binary.ByteOrder, in input, out output, i int) {
 	data := buildInput(in, order)
 	buf := bytes.NewReader(data)
-	tg, err := DecodeTag(buf, order)
+	tg, err := DecodeTag(buf, order, false)
 	if err != nil {
 		t.Errorf("(%v) tag %v%+v decode failed: %v", order, i, in, err)
 		return
@@ -209,7 +209,7 @@ func TestDecode(t *testing.T) {
 func TestDecodeTag_blob(t *testing.T) {
 	buf := bytes.NewReader(data())
 	buf.Seek(10, 1)
-	tg, err := DecodeTag(buf, binary.LittleEndian)
+	tg, err := DecodeTag(buf, binary.LittleEndian, false)
 	if err != nil {
 		t.Fatalf("tag decode failed: %v", err)
 	}


### PR DESCRIPTION
This change adds support for parsing IFDs from BigTIFF files and also adds support for 2 more BigTIFF-specific data types (8 byte long and 8 byte signed long).

I'm aware that it's API-breaking, as it adds an `IsBig` field to the `tiff` struct, `isBigTIFF` boolean flags to a few parsing methods, and also changes some struct fields from 32 bit to 64 bit ints to properly support the BigTIFF offsets.

Would it make sense to refactor this by separating bigtiff support into a new package, or should this wait for a new version of the library?