### PR TITLE
fix: Handle exif.MakerNote is empty in Parse (Nikon)

### DIFF
--- a/mknote/mknote.go
+++ b/mknote/mknote.go
@@ -55,7 +55,7 @@ func (_ *nikonV3) Parse(x *exif.Exif) error {
 	m, err := x.Get(exif.MakerNote)
 	if err != nil {
 		return nil
-	} else if bytes.Compare(m.Val[:6], []byte("Nikon\000")) != 0 {
+	} else if len(m.Val) < 6 || bytes.Compare(m.Val[:6], []byte("Nikon\000")) != 0 {
 		return nil
 	}
 


### PR DESCRIPTION
Pull request to fix the crash when exif.MakerNote is empty in Parse (Nikon) : 
```
panic: runtime error: slice bounds out of range

goroutine 19 [running]:
github.com/xor-gate/goexif2/mknote.(*nikonV3).Parse(0x1443ec0, 0xc420150ea0, 0x0, 0x0)
	/Users/vomnes/go/src/github.com/xor-gate/goexif2/mknote/mknote.go:58 +0x2b4
github.com/xor-gate/goexif2/exif.Decode(0x12e6920, 0xc4204a4060, 0x2, 0x42, 0x0)
	/Users/vomnes/go/src/github.com/xor-gate/goexif2/exif/exif.go:331 +0x366
```