### PR TITLE
fix: Improve exif.MakerNote value validity check (NikonV3)

### DIFF
--- a/mknote/mknote.go
+++ b/mknote/mknote.go
@@ -50,12 +50,14 @@ func (_ *canon) Parse(x *exif.Exif) error {
 
 type nikonV3 struct{}
 
+func (_ *nikonV3) hasValidMakerNoteValue(m *tiff.Tag) bool {
+	return !(len(m.Val) < 6 || bytes.Compare(m.Val[:6], []byte("Nikon\000")) != 0)
+}
+
 // Parse decodes all Nikon makernote data found in x and adds it to x.
 func (_ *nikonV3) Parse(x *exif.Exif) error {
 	m, err := x.Get(exif.MakerNote)
-	if err != nil {
-		return nil
-	} else if bytes.Compare(m.Val[:6], []byte("Nikon\000")) != 0 {
+	if err != nil || !NikonV3.hasValidMakerNoteValue(m) {
 		return nil
 	}
 

--- a/mknote/mknote_test.go
+++ b/mknote/mknote_test.go
@@ -1,0 +1,34 @@
+package mknote
+
+import (
+	"testing"
+
+	"github.com/xor-gate/goexif2/tiff"
+)
+
+var tiffMakerNoteValueTests = []struct {
+	makerNoteValue []byte
+	expectedOutput bool
+	testContent    string
+}{
+	{[]byte("Nikon\000"), true, "Valid Nikon value"},
+	{[]byte{0, 0, 0, 0, 0}, false, "Too small - 5"},
+	{nil, false, "Nil"},
+	{[]byte{0, 0, 0, 0, 0, 0}, false, "Right size"},
+	{[]byte("Canon\000"), false, "Not equal to Nikon"},
+	{[]byte("Nikon\00042"), true, "Contains Nikon"},
+}
+
+func TestNikonV3hasValidMakerNoteValue(t *testing.T) {
+	var tiffMakerNote *tiff.Tag
+	var isValid bool
+	for _, tt := range tiffMakerNoteValueTests {
+		tiffMakerNote = &tiff.Tag{
+			Val: tt.makerNoteValue,
+		}
+		isValid = NikonV3.hasValidMakerNoteValue(tiffMakerNote)
+		if isValid != tt.expectedOutput {
+			t.Errorf("Expected the output '%t' has '%t' - Test type: %s", tt.expectedOutput, isValid, tt.testContent)
+		}
+	}
+}


### PR DESCRIPTION
Pull request to improve the exif.MakerNote value validity check on NikonV3 with unit tests.
This update fix the crash when exif.MakerNote is empty in Parse:
```
panic: runtime error: slice bounds out of range

goroutine 19 [running]:
github.com/xor-gate/goexif2/mknote.(*nikonV3).Parse(0x1443ec0, 0xc420150ea0, 0x0, 0x0)
	/Users/vomnes/go/src/github.com/xor-gate/goexif2/mknote/mknote.go:58 +0x2b4
github.com/xor-gate/goexif2/exif.Decode(0x12e6920, 0xc4204a4060, 0x2, 0x42, 0x0)
	/Users/vomnes/go/src/github.com/xor-gate/goexif2/exif/exif.go:331 +0x366
```