### PR TITLE
Fix panic by checking slice length in Rat2() function

### DIFF
--- a/tiff/tag.go
+++ b/tiff/tag.go
@@ -351,6 +351,9 @@ func (t *Tag) Rat2(i int) (num, den int64, err error) {
 	if t.format != RatVal {
 		return 0, 0, t.typeErr(RatVal)
 	}
+	if len(t.ratVals[i]) < 2 {
+		return 0, 0, newTiffError("ratVals is not long enough", nil)
+	}
 	return t.ratVals[i][0], t.ratVals[i][1], nil
 }
 


### PR DESCRIPTION
I get a panic in production using this library:

```
goroutine 50097225 [running]:
panic(0xd86800, 0xc000350f00)
	/usr/local/go/src/runtime/panic.go:679 +0x1b2
github.com/xor-gate/goexif2/tiff.(*Tag).Rat2(...)
	/go/pkg/mod/github.com/xor-gate/goexif2@v1.1.0/tiff/tag.go:354
github.com/xor-gate/goexif2/exif.parse3Rat2(0xc0004ca280, 0x0, 0x0, 0x0, 0xe, 0xc000350eb1)
	/go/pkg/mod/github.com/xor-gate/goexif2@v1.1.0/exif/exif.go:507 +0x209
github.com/xor-gate/goexif2/exif.tagDegrees(0xc0004ca280, 0xc0004e30b0, 0xdf55f7, 0xe)
	/go/pkg/mod/github.com/xor-gate/goexif2@v1.1.0/exif/exif.go:525 +0x104
github.com/xor-gate/goexif2/exif.(*Exif).LatLong(0xc0004e3080, 0x0, 0xed5dccfe5, 0x15704c0, 0x0)
	/go/pkg/mod/github.com/xor-gate/goexif2@v1.1.0/exif/exif.go:563 +0x1a9
```

This should fix this panic by checking the slice length prior to accessing it.